### PR TITLE
install Sentry CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN sudo pip install awscli
 # Puppeteer
 RUN sudo yarn global add puppeteer@1.8.0 && yarn cache clean
 
+# Sentry CLI
+RUN sudo curl -sL https://sentry.io/get-cli/ | bash
+
 ENV NODE_PATH="/usr/local/share/.config/yarn/global/node_modules:${NODE_PATH}"
 
 ENV PATH="/tools:${PATH}"


### PR DESCRIPTION
We installed the `sentry-cli` tool in the pex-client config.yml, but the installation broke due to miassing sudo rights.
I removed the installation here: https://github.com/signavio/pex-client/commit/6f879240e2beaa2d153bc4f130518b9eb4b1dde3
and instead added it to the docker image now.